### PR TITLE
Issue #19: Add Test Data SQL file

### DIFF
--- a/server/src/main/kotlin/com/hockey/elo/elotracker/elohistory/repository/EloHistoryRepository.kt
+++ b/server/src/main/kotlin/com/hockey/elo/elotracker/elohistory/repository/EloHistoryRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface EloHistoryRepository: JpaRepository<EloHistoryRecord, Long>
+interface EloHistoryRepository: JpaRepository<EloHistoryRecord, Long> {
+  fun findAllByUserId(userId: Long): List<EloHistoryRecord>
+}

--- a/server/src/main/kotlin/com/hockey/elo/elotracker/elohistory/service/EloHistoryService.kt
+++ b/server/src/main/kotlin/com/hockey/elo/elotracker/elohistory/service/EloHistoryService.kt
@@ -11,7 +11,7 @@ class EloHistoryService(private val eloHistoryRepository: EloHistoryRepository) 
 
   //should return last 6 months of a user's elo history
   fun retrieveEloHistoryFor(userId: Long): List<EloHistoryRecord> {
-    val records = eloHistoryRepository.findAllById(listOf(userId))
+    val records = eloHistoryRepository.findAllByUserId(userId)
     //probably a better way to do this but it is 5 AM and I have 4 hours of sleep
     return records.filter { record ->
       record.date.after(

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.application.name = "Elo Tracker"
 spring.datasource.url = jdbc:mysql://localhost:3306/elotracker?useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username = ${ELO_TRACKER_DB_USERNAME}
 spring.datasource.password = ${ELO_TRACKER_DB_PASSWORD}
+spring.datasource.initialization-mode = always
 
 ## Hibernate Properties
 

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,0 +1,58 @@
+INSERT INTO user_record (elo, losses, name, rfid, wins) VALUES (1200, 0, 'Test User 1', 'testrfid1', 0);
+INSERT INTO user_record (elo, losses, name, rfid, wins) VALUES (982, 6, 'Test User 2', 'testrfid2', 4);
+INSERT INTO user_record (elo, losses, name, rfid, wins) VALUES (1387, 4, 'Test User 3', 'testrfid3', 6);
+
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 0, 3, 1, 3);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 1, 3, 5, 3);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 0, 3, 3, 3);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 0, 3, 2, 3);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 1, 3, 8, 3);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 0, 3, 1, 3);
+
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 2, 3, 1, 2);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 4, 3, 1, 2);
+
+INSERT INTO match_record (player_one_id, player_one_score, player_two_id, player_two_score, winner_id)
+VALUES (2, 6, 3, 1, 2);
+
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-01 12:00:00', 1200, 1);
+
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-01 12:00:00', 1200, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-02 12:00:00', 1250, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-03 12:00:00', 1300, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-04 12:00:00', 1325, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-05 12:00:00', 1350, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-06 12:00:00', 1250, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-07 12:00:00', 1190, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-08 12:00:00', 1100, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-09 12:00:00', 1040, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-10 12:00:00', 1000, 2);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-11 12:00:00', 982, 2);
+
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-01 12:00:00', 1200, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-02 12:00:00', 1150, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-03 12:00:00', 1090, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-04 12:00:00', 975, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-05 12:00:00', 950, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-06 12:00:00', 1000, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-07 12:00:00', 1040, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-08 12:00:00', 1159, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-09 12:00:00', 1260, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-10 12:00:00', 1301, 3);
+INSERT INTO elo_history_record (date, elo, user_id) VALUES ('2019-01-11 12:00:00', 1387, 3);


### PR DESCRIPTION
#### Description
Adds a `data.sql` to the resources that will load in some dummy data for testing and early consumption purposes.

#### Technical Details
- Inserts 3 users, 10 matches, and 13 elo history records into your local mysql db
- This data should only be loaded once
- Also tacked on a fix to Elo History where the wrong call was being made to the repository.