### PR TITLE
Add basic users table view to the web app

### DIFF
--- a/server/src/main/elo-tracker-web/package-lock.json
+++ b/server/src/main/elo-tracker-web/package-lock.json
@@ -10570,6 +10570,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.2.tgz",
+      "integrity": "sha512-opKtsxjp9eOcFWdp6xLQPLmRGgfM932Tl56U9chYTnoWqKxQ8M20N7AkdEbM5beUh6wICoFGYugAX9vQjyJLFg=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/server/src/main/elo-tracker-web/package.json
+++ b/server/src/main/elo-tracker-web/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --port=8081",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
     "axios": "^0.18.0",
     "vue": "^2.5.21",
+    "vue-router": "^3.0.1",
     "vuetify": "^1.3.0"
   },
   "devDependencies": {

--- a/server/src/main/elo-tracker-web/src/App.vue
+++ b/server/src/main/elo-tracker-web/src/App.vue
@@ -5,13 +5,15 @@
       permanent
       app
       clipped
+      width="200"
     >
     <v-list>
       <v-list-tile
         v-for="link in links"
         :key="link.title"
-        :href="link.href"
+        :to="link.href"
       >
+      <!-- <router-link :to="link.href"> -->
         <v-list-tile-action>
           <v-icon>{{ link.icon }}</v-icon>
         </v-list-tile-action>
@@ -19,6 +21,7 @@
         <v-list-tile-content>
           <v-list-tile-title>{{ link.title }}</v-list-tile-title>
         </v-list-tile-content>
+        <!-- </router-link> -->
       </v-list-tile>
     </v-list>
     </v-navigation-drawer>
@@ -31,6 +34,7 @@
     </v-toolbar>
 
     <v-content>
+      <router-view></router-view>
     </v-content>
   </v-app>
 </template>

--- a/server/src/main/elo-tracker-web/src/config/http.js
+++ b/server/src/main/elo-tracker-web/src/config/http.js
@@ -1,0 +1,5 @@
+import axios from 'axios'
+
+export const http = axios.create({
+  baseURL: 'http://localhost:8080/api/', //base URL goes here
+})

--- a/server/src/main/elo-tracker-web/src/main.js
+++ b/server/src/main/elo-tracker-web/src/main.js
@@ -1,9 +1,11 @@
 import Vue from 'vue'
 import './plugins/vuetify'
 import App from './App.vue'
+import router from './router'
 
 Vue.config.productionTip = false
 
 new Vue({
-  render: h => h(App),
+  router,
+  render: h => h(App)
 }).$mount('#app')

--- a/server/src/main/elo-tracker-web/src/router.js
+++ b/server/src/main/elo-tracker-web/src/router.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import Router from 'vue-router'
+import Users from './views/Users.vue'
+
+Vue.use(Router)
+
+export default new Router({
+  routes: [
+    {
+      path: '/users',
+      name: 'users',
+      component: Users
+    }
+  ]
+})

--- a/server/src/main/elo-tracker-web/src/views/Users.vue
+++ b/server/src/main/elo-tracker-web/src/views/Users.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-card class="ma-3">
+    <v-card-title> Users </v-card-title>
+
+    <v-data-table
+      :headers="tableHeaders"
+      :items="users"
+      class="elevation-1"
+      v-if="users.length > 0"
+    >
+    <template slot="items" slot-scope="props">
+      <td>{{ props.item.name }}</td>
+      <td class="text-xs-right">{{ props.item.elo }}</td>
+      <td class="text-xs-right">{{ props.item.wins }}</td>
+      <td class="text-xs-right">{{ props.item.losses }}</td>
+    </template>
+  </v-data-table>
+
+  </v-card>
+</template>
+
+<script>
+import { http } from '../config/http.js'
+
+export default {
+  data () {
+    return {
+      tableHeaders: [
+        { text: 'Name', align: 'left', sortable: true, value: 'name' },
+        { text: 'Elo', align: 'right', sortable: true, value: 'elo' },
+        { text: 'Wins', align: 'right', sortable: true, value: 'wins' },
+        { text: 'Losses', align: 'right', sortable: true, value: 'lossses' }
+      ],
+      users: []
+    }
+  },
+
+  methods: {
+    getUsers() {
+      http.get('v1/users')
+      .then(res => {
+        this.users = res.data
+      })
+      .catch(err => {
+        console.log(err)
+      })
+    }
+  },
+
+  mounted() {
+    this.getUsers()
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/server/src/main/kotlin/com/hockey/elo/elotracker/user/controller/UserController.kt
+++ b/server/src/main/kotlin/com/hockey/elo/elotracker/user/controller/UserController.kt
@@ -7,11 +7,12 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
 @Validated
+@CrossOrigin(origins = ["http://localhost:8081"])
 @RestController
 class UserController(
     private val userService: UserService
 ) {
-
+  
   @GetMapping("/api/v1/users")
   fun retrieveAllUsers(): List<UserDTO> =
       userService.retrieveAllUsers()

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.datasource.initialization-mode = always
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.ddl-auto = validate
 
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
#### Description
Add in a table based view in the web app that retrieves users from the API

#### Technical Details
- Also switch back to create-drop since the data was being duplicated
  looking for help on that front
- Set up CORS (crudely) on the Users controller, any help there would
  be greatly appreciated
- Adds Vue-Router to the web app as well as example routing config
- Add axios to web app with default values exported as `http`