### PR TITLE
ELO-70: Dockerize server application

### DIFF
--- a/server/src/main/kotlin/com/hockey/elo/elotracker/configurations/SecurityConfigurations.kt
+++ b/server/src/main/kotlin/com/hockey/elo/elotracker/configurations/SecurityConfigurations.kt
@@ -28,7 +28,7 @@ class SecurityConfigurations(
         auth.jdbcAuthentication().dataSource(dataSource)
                 .usersByUsernameQuery(
                         "select username, password, enabled from users where username = ?")
-                .authoritiesByUsernameQuery("select username, authority from authorities where username=?")
+                .authoritiesByUsernameQuery("select username, authority from authorities where username = ?")
     }
 
     override fun configure(http: HttpSecurity?) {

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -7,11 +7,13 @@ spring:
     password: ${ELO_TRACKER_DB_PASSWORD}
     initialization-mode: always
   jpa:
+    hibernate:
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        jdbc.time_zone: UTC
-        ddl-auto: create-drop
+        jdbc:
+          time_zone: UTC
 logging:
   level:
     org:
@@ -31,4 +33,4 @@ spring:
   profiles: docker
   datasource:
     url: jdbc:mysql://host.docker.internal:3306/elotracker?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&useLegacyDatetimeCode=false
-    initialization-mode: never
+    initialization-mode: always

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-#Users and Authorities
-INSERT INTO users(username, password, enabled) VALUES ('pi','$2a$10$0Sv774g9QW7AsgVvwdJP8OodPmdML6xG1SU369zUEp1ka41c6uSiu', true);
+# Users and Authorities
+;INSERT INTO users(username, password, enabled) VALUES ('pi','$2a$10$0Sv774g9QW7AsgVvwdJP8OodPmdML6xG1SU369zUEp1ka41c6uSiu', true);
 INSERT INTO authorities (username, authority) VALUES ('pi', 'USER');
 
 INSERT INTO users(username, password, enabled) VALUES ('piAdmin','$2a$10$l5dOQ6xrbt4KlnIP8wZY4.a4OCu0zgVjnRSoFDHeYMLI85vVA.wam', true);

--- a/server/src/test/kotlin/com/hockey/elo/elotracker/elohistory/service/EloHistoryServiceTest.kt
+++ b/server/src/test/kotlin/com/hockey/elo/elotracker/elohistory/service/EloHistoryServiceTest.kt
@@ -43,6 +43,21 @@ class EloHistoryServiceTest {
         assertThat(eloHistory.elo).isEqualTo(elo)
     }
 
+//    @Test
+//    fun `createEloHistory-EloHistory is saved with initialization`() {
+//        val newEloHistoryRecord = EloHistoryRecord(0, userId, gameType, 1200, Date())
+//        val passedInEloHistoryRecord = EloHistoryRecord(0, userId, gameType, elo, Date())
+//
+//        `when`(eloHistoryRepository.findAllByUserIdAndGameType(userId, gameType))
+//                .thenReturn(mutableListOf())
+//        `when`(eloHistoryRepository.save(any(EloHistoryRecord::class.java)))
+//                .thenReturn(newEloHistoryRecord)
+//                .thenReturn(passedInEloHistoryRecord)
+//
+//        eloHistoryService.createEloHistory(userId, gameType, elo)
+//        verify(eloHistoryRepository).save(newEloHistoryRecord)
+//    }
+
     @Test
     fun `retrieveEloHistoryFor-EloHistoryRecord is converted to EloHistory`() {
         `when`(eloHistoryRepository.findAllByUserIdAndGameType(userId, gameType))


### PR DESCRIPTION
#### Description
Updates yaml to fix hibernate properties
Updates data.sql to fix loading first user not inserting

#### Technical Details
The create-drop property was not correctly placed in the yaml file. For some reason they are in different paths from properties and yaml format

I placed semicolon in from of the first insert in data.sql. This seems fix the first sql statement to always run and insert our pi user.